### PR TITLE
Support for Angstrom version 0.7 and later

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,2 +1,1 @@
-let pkgs = import <nixpkgs> {};
-in pkgs.ocamlPackages_4_02.callPackage ./logbook.nix {}
+(import <nixpkgs> {}).ocamlPackages.callPackage ./logbook.nix {}

--- a/src/logbook.ml
+++ b/src/logbook.ml
@@ -4,7 +4,7 @@ open Lwt.Infix
 let parse_file f =
   Lwt_io.with_file Lwt_io.Input f (fun c ->
     Lwt_io.read c >>= (fun s ->
-      return (Angstrom.parse_only Log.log_parser (`String s))))
+      return (Angstrom.parse_string Log.log_parser s)))
 
 let input_file = ref None
 let privacy = ref Log.Public


### PR DESCRIPTION
In Angstrom 0.7 the interface changed a bit and `parse_only` is no longer there. Instead there is `parse_string` and `parse_bigstring`.

I didn't actually add a version comparison to make it backwards-compatible.

Tested with the example log file.